### PR TITLE
Use MONGO_URI environment variable for MongoDB connection

### DIFF
--- a/fastapi-app/app/database.py
+++ b/fastapi-app/app/database.py
@@ -2,8 +2,8 @@
 import os
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 
-MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
-_client = AsyncIOMotorClient(MONGODB_URI)
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+_client = AsyncIOMotorClient(MONGO_URI)
 _db = _client["app_db"]
 
 

--- a/fastapi-app/tests/test_database_env.py
+++ b/fastapi-app/tests/test_database_env.py
@@ -1,0 +1,17 @@
+"""Tests for MongoDB configuration."""
+
+import importlib
+
+import app.database as db
+
+
+def test_uses_mongo_uri_env(monkeypatch) -> None:
+    """Ensure database module reads ``MONGO_URI`` environment variable."""
+    monkeypatch.setenv("MONGO_URI", "mongodb://example.com:27017")
+    importlib.reload(db)
+    assert db.MONGO_URI == "mongodb://example.com:27017"
+
+    monkeypatch.delenv("MONGO_URI", raising=False)
+    importlib.reload(db)
+    assert db.MONGO_URI == "mongodb://localhost:27017"
+


### PR DESCRIPTION
## Summary
- switch MongoDB configuration to read the `MONGO_URI` environment variable
- add tests verifying `MONGO_URI` is applied and can fallback to local

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee6971a1c83258b2c14f317dfa46d