### PR TITLE
Add flight search and detail endpoints

### DIFF
--- a/fastapi-app/app/database.py
+++ b/fastapi-app/app/database.py
@@ -14,3 +14,8 @@ _db = _client[_db_name]
 def get_user_collection() -> AsyncIOMotorCollection:
     """Return the MongoDB collection for users."""
     return _db["users"]
+
+
+def get_flight_collection() -> AsyncIOMotorCollection:
+    """Return the MongoDB collection for flights."""
+    return _db["flights"]

--- a/fastapi-app/app/main.py
+++ b/fastapi-app/app/main.py
@@ -1,10 +1,11 @@
 """FastAPI application entry point."""
 from fastapi import FastAPI
 
-from .routers import auth
+from .routers import auth, flights
 
 app = FastAPI()
 app.include_router(auth.router)
+app.include_router(flights.router)
 
 
 @app.get("/")

--- a/fastapi-app/app/models/flight.py
+++ b/fastapi-app/app/models/flight.py
@@ -1,0 +1,13 @@
+"""Data model for flights stored in MongoDB."""
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class FlightInDB(BaseModel):
+    """Representation of a flight in the database."""
+    id: str
+    origin: str
+    destination: str
+    departure_time: datetime
+    arrival_time: datetime
+    price: float

--- a/fastapi-app/app/repositories/flight_repository.py
+++ b/fastapi-app/app/repositories/flight_repository.py
@@ -1,0 +1,29 @@
+"""Flight repository interacting with MongoDB."""
+from typing import List, Optional
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from ..models.flight import FlightInDB
+
+
+class FlightRepository:
+    """Repository for flight read operations."""
+
+    def __init__(self, collection: AsyncIOMotorCollection) -> None:
+        self.collection = collection
+
+    async def search(self, origin: str, destination: str) -> List[FlightInDB]:
+        """Return flights matching origin and destination."""
+        cursor = self.collection.find({"origin": origin, "destination": destination})
+        results = []
+        async for document in cursor:
+            document["id"] = document.pop("_id")
+            results.append(FlightInDB(**document))
+        return results
+
+    async def get_by_id(self, flight_id: str) -> Optional[FlightInDB]:
+        """Return a flight by its identifier."""
+        document = await self.collection.find_one({"_id": flight_id})
+        if document:
+            document["id"] = document.pop("_id")
+            return FlightInDB(**document)
+        return None

--- a/fastapi-app/app/routers/flights.py
+++ b/fastapi-app/app/routers/flights.py
@@ -1,0 +1,37 @@
+"""Flight API routes."""
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from ..database import get_flight_collection
+from ..repositories.flight_repository import FlightRepository
+from ..schemas.flight import Flight
+from ..services.flight_service import get_flight, search_flights
+
+router = APIRouter(prefix="/flights", tags=["flights"])
+
+
+def get_flight_repo(collection: AsyncIOMotorCollection = Depends(get_flight_collection)) -> FlightRepository:
+    """Provide a flight repository dependency."""
+    return FlightRepository(collection)
+
+
+@router.get("", response_model=List[Flight])
+async def search(
+    origin: str = Query(...),
+    destination: str = Query(...),
+    repo: FlightRepository = Depends(get_flight_repo),
+) -> List[Flight]:
+    """Search for flights by origin and destination."""
+    flights_db = await search_flights(repo, origin, destination)
+    return [Flight(**flight.model_dump()) for flight in flights_db]
+
+
+@router.get("/{flight_id}", response_model=Flight)
+async def get(flight_id: str, repo: FlightRepository = Depends(get_flight_repo)) -> Flight:
+    """Retrieve detailed information about a flight."""
+    flight_db = await get_flight(repo, flight_id)
+    if not flight_db:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flight not found")
+    return Flight(**flight_db.model_dump())

--- a/fastapi-app/app/schemas/flight.py
+++ b/fastapi-app/app/schemas/flight.py
@@ -1,0 +1,13 @@
+"""Pydantic schemas for flight operations."""
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class Flight(BaseModel):
+    """Schema representing flight information."""
+    id: str
+    origin: str
+    destination: str
+    departure_time: datetime
+    arrival_time: datetime
+    price: float

--- a/fastapi-app/app/services/flight_service.py
+++ b/fastapi-app/app/services/flight_service.py
@@ -1,0 +1,15 @@
+"""Service layer for flight operations."""
+from typing import List, Optional
+
+from ..models.flight import FlightInDB
+from ..repositories.flight_repository import FlightRepository
+
+
+async def search_flights(repo: FlightRepository, origin: str, destination: str) -> List[FlightInDB]:
+    """Search flights by origin and destination."""
+    return await repo.search(origin, destination)
+
+
+async def get_flight(repo: FlightRepository, flight_id: str) -> Optional[FlightInDB]:
+    """Retrieve a flight by its identifier."""
+    return await repo.get_by_id(flight_id)

--- a/fastapi-app/tests/test_flights.py
+++ b/fastapi-app/tests/test_flights.py
@@ -1,0 +1,71 @@
+"""Tests for flight endpoints."""
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import mongomock_motor
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+
+# Add fastapi-app directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.database import get_flight_collection  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def flight_collection() -> AsyncIOMotorCollection:
+    """Override MongoDB dependency with remote or mock collection."""
+    mongo_uri = os.getenv("MONGO_URI")
+    client = None
+    try:
+        if mongo_uri:
+            client = AsyncIOMotorClient(mongo_uri, serverSelectionTimeoutMS=2000)
+            await client.admin.command("ping")
+        else:
+            raise RuntimeError("Missing MONGO_URI")
+    except Exception:
+        client = mongomock_motor.AsyncMongoMockClient()
+
+    collection = client["test_db"]["flights"]
+    await collection.delete_many({})
+    app.dependency_overrides[get_flight_collection] = lambda: collection
+    try:
+        yield collection
+    finally:
+        await collection.delete_many({})
+        app.dependency_overrides.clear()
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_search_and_get_flight(flight_collection: AsyncIOMotorCollection) -> None:
+    """Ensure flights can be searched and retrieved."""
+    flight = {
+        "_id": "AB123",
+        "origin": "MEX",
+        "destination": "GDL",
+        "departure_time": datetime(2023, 1, 1, 10, 0, 0),
+        "arrival_time": datetime(2023, 1, 1, 12, 0, 0),
+        "price": 1500.0,
+    }
+    await flight_collection.insert_one(flight)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/flights", params={"origin": "MEX", "destination": "GDL"})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "AB123"
+        assert data[0]["price"] == 1500.0
+
+        response = await ac.get("/flights/AB123")
+        assert response.status_code == 200
+        detail = response.json()
+        assert detail["origin"] == "MEX"
+        assert detail["destination"] == "GDL"


### PR DESCRIPTION
## Summary
- add flight model, repository, service, and router
- support searching flights and retrieving flight details
- include tests for flight queries

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f564c5e1883259cafe95ae2d6b0da