### PR TITLE
Add reservation system with payment simulation

### DIFF
--- a/fastapi-app/app/database.py
+++ b/fastapi-app/app/database.py
@@ -19,3 +19,8 @@ def get_user_collection() -> AsyncIOMotorCollection:
 def get_flight_collection() -> AsyncIOMotorCollection:
     """Return the MongoDB collection for flights."""
     return _db["flights"]
+
+
+def get_reservation_collection() -> AsyncIOMotorCollection:
+    """Return the MongoDB collection for reservations."""
+    return _db["reservations"]

--- a/fastapi-app/app/main.py
+++ b/fastapi-app/app/main.py
@@ -1,11 +1,12 @@
 """FastAPI application entry point."""
 from fastapi import FastAPI
 
-from .routers import auth, flights
+from .routers import auth, flights, reservations
 
 app = FastAPI()
 app.include_router(auth.router)
 app.include_router(flights.router)
+app.include_router(reservations.router)
 
 
 @app.get("/")

--- a/fastapi-app/app/models/flight.py
+++ b/fastapi-app/app/models/flight.py
@@ -11,3 +11,4 @@ class FlightInDB(BaseModel):
     departure_time: datetime
     arrival_time: datetime
     price: float
+    seats: int

--- a/fastapi-app/app/models/reservation.py
+++ b/fastapi-app/app/models/reservation.py
@@ -1,0 +1,11 @@
+"""Data model for reservations stored in MongoDB."""
+from pydantic import BaseModel
+
+
+class ReservationInDB(BaseModel):
+    """Representation of a reservation in the database."""
+    id: str
+    flight_id: str
+    username: str
+    seat_number: int
+    paid: bool = False

--- a/fastapi-app/app/repositories/reservation_repository.py
+++ b/fastapi-app/app/repositories/reservation_repository.py
@@ -1,0 +1,44 @@
+"""Reservation repository interacting with MongoDB."""
+from typing import List, Optional
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from ..models.reservation import ReservationInDB
+
+
+class ReservationRepository:
+    """Repository for reservation operations."""
+
+    def __init__(self, collection: AsyncIOMotorCollection) -> None:
+        self.collection = collection
+
+    async def count_by_flight(self, flight_id: str) -> int:
+        """Count reservations for a given flight."""
+        return await self.collection.count_documents({"flight_id": flight_id})
+
+    async def create(self, reservation: ReservationInDB) -> str:
+        """Insert a new reservation and return its identifier."""
+        document = reservation.model_dump()
+        document["_id"] = document.pop("id")
+        await self.collection.insert_one(document)
+        return reservation.id
+
+    async def list_by_user(self, username: str) -> List[ReservationInDB]:
+        """List reservations belonging to a user."""
+        cursor = self.collection.find({"username": username})
+        results: List[ReservationInDB] = []
+        async for document in cursor:
+            document["id"] = document.pop("_id")
+            results.append(ReservationInDB(**document))
+        return results
+
+    async def get_by_id(self, reservation_id: str) -> Optional[ReservationInDB]:
+        """Retrieve a reservation by its identifier."""
+        document = await self.collection.find_one({"_id": reservation_id})
+        if document:
+            document["id"] = document.pop("_id")
+            return ReservationInDB(**document)
+        return None
+
+    async def set_paid(self, reservation_id: str) -> None:
+        """Mark a reservation as paid."""
+        await self.collection.update_one({"_id": reservation_id}, {"$set": {"paid": True}})

--- a/fastapi-app/app/routers/reservations.py
+++ b/fastapi-app/app/routers/reservations.py
@@ -1,0 +1,98 @@
+"""Reservation API routes."""
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from ..database import get_flight_collection, get_reservation_collection
+from ..repositories.flight_repository import FlightRepository
+from ..repositories.reservation_repository import ReservationRepository
+from ..schemas.reservation import Reservation, ReservationCreate
+from ..services.auth_service import ALGORITHM, SECRET_KEY
+from ..services.reservation_service import (
+    FlightNotFoundError,
+    NoSeatsAvailableError,
+    create_reservation,
+    list_reservations,
+    pay_reservation,
+)
+
+router = APIRouter(prefix="/reservations", tags=["reservations"])
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def get_flight_repo(
+    collection: AsyncIOMotorCollection = Depends(get_flight_collection),
+) -> FlightRepository:
+    """Provide a flight repository dependency."""
+    return FlightRepository(collection)
+
+
+def get_reservation_repo(
+    collection: AsyncIOMotorCollection = Depends(get_reservation_collection),
+) -> ReservationRepository:
+    """Provide a reservation repository dependency."""
+    return ReservationRepository(collection)
+
+
+async def get_current_username(token: str = Depends(oauth2_scheme)) -> str:
+    """Decode the JWT token and return the username."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication credentials",
+            )
+        return username
+    except JWTError as exc:  # noqa: B904
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+        ) from exc
+
+
+@router.post("", response_model=Reservation, status_code=status.HTTP_201_CREATED)
+async def create(
+    data: ReservationCreate,
+    username: str = Depends(get_current_username),
+    flight_repo: FlightRepository = Depends(get_flight_repo),
+    reservation_repo: ReservationRepository = Depends(get_reservation_repo),
+) -> Reservation:
+    """Create a reservation for the current user."""
+    try:
+        reservation_db = await create_reservation(
+            flight_repo, reservation_repo, data.flight_id, username
+        )
+    except FlightNotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flight not found")
+    except NoSeatsAvailableError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No seats available")
+    return Reservation(**reservation_db.model_dump())
+
+
+@router.get("", response_model=List[Reservation])
+async def list_mine(
+    username: str = Depends(get_current_username),
+    reservation_repo: ReservationRepository = Depends(get_reservation_repo),
+) -> List[Reservation]:
+    """List reservations for the current user."""
+    reservations_db = await list_reservations(reservation_repo, username)
+    return [Reservation(**res.model_dump()) for res in reservations_db]
+
+
+@router.post("/{reservation_id}/pay", response_model=Reservation)
+async def pay(
+    reservation_id: str,
+    username: str = Depends(get_current_username),
+    reservation_repo: ReservationRepository = Depends(get_reservation_repo),
+) -> Reservation:
+    """Mark a reservation as paid."""
+    reservation_db = await pay_reservation(reservation_repo, reservation_id, username)
+    if not reservation_db:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Reservation not found")
+    return Reservation(**reservation_db.model_dump())

--- a/fastapi-app/app/schemas/flight.py
+++ b/fastapi-app/app/schemas/flight.py
@@ -11,3 +11,4 @@ class Flight(BaseModel):
     departure_time: datetime
     arrival_time: datetime
     price: float
+    seats: int

--- a/fastapi-app/app/schemas/reservation.py
+++ b/fastapi-app/app/schemas/reservation.py
@@ -1,0 +1,16 @@
+"""Pydantic schemas for reservation operations."""
+from pydantic import BaseModel
+
+
+class ReservationCreate(BaseModel):
+    """Schema for creating a reservation."""
+    flight_id: str
+
+
+class Reservation(BaseModel):
+    """Schema representing reservation information."""
+    id: str
+    flight_id: str
+    username: str
+    seat_number: int
+    paid: bool

--- a/fastapi-app/app/services/reservation_service.py
+++ b/fastapi-app/app/services/reservation_service.py
@@ -1,0 +1,59 @@
+"""Service layer for reservation operations."""
+from typing import List
+from uuid import uuid4
+
+from ..models.reservation import ReservationInDB
+from ..repositories.flight_repository import FlightRepository
+from ..repositories.reservation_repository import ReservationRepository
+
+
+class FlightNotFoundError(Exception):
+    """Raised when the flight does not exist."""
+
+
+class NoSeatsAvailableError(Exception):
+    """Raised when the flight has no available seats."""
+
+
+async def create_reservation(
+    flight_repo: FlightRepository,
+    reservation_repo: ReservationRepository,
+    flight_id: str,
+    username: str,
+) -> ReservationInDB:
+    """Create a reservation if seats are available."""
+    flight = await flight_repo.get_by_id(flight_id)
+    if not flight:
+        raise FlightNotFoundError
+    reserved = await reservation_repo.count_by_flight(flight_id)
+    if reserved >= flight.seats:
+        raise NoSeatsAvailableError
+    seat_number = reserved + 1
+    reservation = ReservationInDB(
+        id=str(uuid4()),
+        flight_id=flight_id,
+        username=username,
+        seat_number=seat_number,
+        paid=False,
+    )
+    await reservation_repo.create(reservation)
+    return reservation
+
+
+async def list_reservations(
+    reservation_repo: ReservationRepository, username: str
+) -> List[ReservationInDB]:
+    """List reservations for a given user."""
+    return await reservation_repo.list_by_user(username)
+
+
+async def pay_reservation(
+    reservation_repo: ReservationRepository, reservation_id: str, username: str
+) -> ReservationInDB | None:
+    """Mark a reservation as paid if it belongs to the user."""
+    reservation = await reservation_repo.get_by_id(reservation_id)
+    if not reservation or reservation.username != username:
+        return None
+    await reservation_repo.set_paid(reservation_id)
+    reservation.paid = True
+    return reservation

--- a/fastapi-app/tests/test_flights.py
+++ b/fastapi-app/tests/test_flights.py
@@ -52,6 +52,7 @@ async def test_search_and_get_flight(flight_collection: AsyncIOMotorCollection) 
         "departure_time": datetime(2023, 1, 1, 10, 0, 0),
         "arrival_time": datetime(2023, 1, 1, 12, 0, 0),
         "price": 1500.0,
+        "seats": 1,
     }
     await flight_collection.insert_one(flight)
 

--- a/fastapi-app/tests/test_reservations.py
+++ b/fastapi-app/tests/test_reservations.py
@@ -1,0 +1,90 @@
+"""Tests for reservation endpoints."""
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import mongomock_motor
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+# Add fastapi-app directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app  # noqa: E402
+from app.database import (  # noqa: E402
+    get_flight_collection,
+    get_reservation_collection,
+    get_user_collection,
+)
+
+
+@pytest_asyncio.fixture
+async def setup_collections() -> tuple[AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection]:
+    """Override MongoDB dependencies with mock collections."""
+    client = mongomock_motor.AsyncMongoMockClient()
+    user_collection = client["test_db"]["users"]
+    flight_collection = client["test_db"]["flights"]
+    reservation_collection = client["test_db"]["reservations"]
+    await user_collection.delete_many({})
+    await flight_collection.delete_many({})
+    await reservation_collection.delete_many({})
+    app.dependency_overrides[get_user_collection] = lambda: user_collection
+    app.dependency_overrides[get_flight_collection] = lambda: flight_collection
+    app.dependency_overrides[get_reservation_collection] = lambda: reservation_collection
+    try:
+        yield user_collection, flight_collection, reservation_collection
+    finally:
+        await user_collection.delete_many({})
+        await flight_collection.delete_many({})
+        await reservation_collection.delete_many({})
+        app.dependency_overrides.clear()
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_reservation_flow(
+    setup_collections: tuple[AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection]
+) -> None:
+    """Ensure reservations can be created, listed, and paid."""
+    user_collection, flight_collection, _ = setup_collections
+    await flight_collection.insert_one(
+        {
+            "_id": "AB123",
+            "origin": "MEX",
+            "destination": "GDL",
+            "departure_time": datetime(2023, 1, 1, 10, 0, 0),
+            "arrival_time": datetime(2023, 1, 1, 12, 0, 0),
+            "price": 1500.0,
+            "seats": 1,
+        }
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post("/auth/register", json={"username": "bob", "password": "secret"})
+        login = await ac.post("/auth/login", json={"username": "bob", "password": "secret"})
+        token = login.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        response = await ac.post(
+            "/reservations", json={"flight_id": "AB123"}, headers=headers
+        )
+        assert response.status_code == 201
+        reservation = response.json()
+        assert reservation["seat_number"] == 1
+
+        response = await ac.post(
+            "/reservations", json={"flight_id": "AB123"}, headers=headers
+        )
+        assert response.status_code == 400
+
+        response = await ac.get("/reservations", headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        reservation_id = data[0]["id"]
+
+        response = await ac.post(f"/reservations/{reservation_id}/pay", headers=headers)
+        assert response.status_code == 200
+        paid = response.json()
+        assert paid["paid"] is True


### PR DESCRIPTION
## Summary
- add seat capacity to flight model and schema
- implement reservation model, repository, service and API endpoints with payment simulation
- add tests for reservations and update flight tests for seat field

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5d67991c8325b49ad668ba5a9086