### PR TITLE
feat: add reservation cancellation

### DIFF
--- a/fastapi-app/app/repositories/reservation_repository.py
+++ b/fastapi-app/app/repositories/reservation_repository.py
@@ -42,3 +42,7 @@ class ReservationRepository:
     async def set_paid(self, reservation_id: str) -> None:
         """Mark a reservation as paid."""
         await self.collection.update_one({"_id": reservation_id}, {"$set": {"paid": True}})
+
+    async def delete(self, reservation_id: str) -> None:
+        """Remove a reservation from the database."""
+        await self.collection.delete_one({"_id": reservation_id})

--- a/fastapi-app/app/services/reservation_service.py
+++ b/fastapi-app/app/services/reservation_service.py
@@ -1,4 +1,5 @@
 """Service layer for reservation operations."""
+from datetime import datetime, timedelta
 from typing import List
 from uuid import uuid4
 
@@ -13,6 +14,14 @@ class FlightNotFoundError(Exception):
 
 class NoSeatsAvailableError(Exception):
     """Raised when the flight has no available seats."""
+
+
+class ReservationNotFoundError(Exception):
+    """Raised when the reservation does not exist or belongs to another user."""
+
+
+class CancellationNotAllowedError(Exception):
+    """Raised when the reservation cannot be cancelled due to time restrictions."""
 
 
 async def create_reservation(
@@ -56,4 +65,25 @@ async def pay_reservation(
         return None
     await reservation_repo.set_paid(reservation_id)
     reservation.paid = True
+    return reservation
+
+
+async def cancel_reservation(
+    flight_repo: FlightRepository,
+    reservation_repo: ReservationRepository,
+    reservation_id: str,
+    username: str,
+    now: datetime | None = None,
+) -> ReservationInDB:
+    """Cancel a reservation if the flight departure is more than 24 hours away."""
+    reservation = await reservation_repo.get_by_id(reservation_id)
+    if not reservation or reservation.username != username:
+        raise ReservationNotFoundError
+    flight = await flight_repo.get_by_id(reservation.flight_id)
+    if not flight:
+        raise FlightNotFoundError
+    current_time = now or datetime.utcnow()
+    if flight.departure_time - current_time <= timedelta(hours=24):
+        raise CancellationNotAllowedError
+    await reservation_repo.delete(reservation_id)
     return reservation


### PR DESCRIPTION
## Summary
- allow deleting reservations more than 24h before departure
- validate time before cancellation and expose DELETE /reservations/{id}
- cover cancellation success and failure cases with new tests

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f678026b483258eca74dca1ce6b03