### PR TITLE
Add reservation error handling tests

### DIFF
--- a/fastapi-app/tests/test_reservations.py
+++ b/fastapi-app/tests/test_reservations.py
@@ -156,3 +156,98 @@ async def test_cannot_cancel_within_24_hours(
 
         response = await ac.delete(f"/reservations/{reservation_id}", headers=headers)
         assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_reservation_nonexistent_flight_returns_404(
+    setup_collections: tuple[
+        AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ]
+) -> None:
+    """Return 404 when attempting to reserve a non-existent flight."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/auth/register", json={"username": "dave", "password": "secret"}
+        )
+        login = await ac.post(
+            "/auth/login", json={"username": "dave", "password": "secret"}
+        )
+        token = login.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        response = await ac.post(
+            "/reservations", json={"flight_id": "ZZ999"}, headers=headers
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pay_reservation_wrong_user_returns_404(
+    setup_collections: tuple[
+        AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ]
+) -> None:
+    """Return 404 when a different user attempts to pay a reservation."""
+    _, flight_collection, _ = setup_collections
+    await flight_collection.insert_one(
+        {
+            "_id": "GH012",
+            "origin": "MEX",
+            "destination": "CUN",
+            "departure_time": datetime(2023, 1, 1, 10, 0, 0),
+            "arrival_time": datetime(2023, 1, 1, 12, 0, 0),
+            "price": 1800.0,
+            "seats": 5,
+        }
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/auth/register", json={"username": "user1", "password": "secret"}
+        )
+        login1 = await ac.post(
+            "/auth/login", json={"username": "user1", "password": "secret"}
+        )
+        token1 = login1.json()["access_token"]
+        headers1 = {"Authorization": f"Bearer {token1}"}
+        reservation = await ac.post(
+            "/reservations", json={"flight_id": "GH012"}, headers=headers1
+        )
+        assert reservation.status_code == 201
+        reservation_id = reservation.json()["id"]
+
+        await ac.post(
+            "/auth/register", json={"username": "user2", "password": "secret"}
+        )
+        login2 = await ac.post(
+            "/auth/login", json={"username": "user2", "password": "secret"}
+        )
+        token2 = login2.json()["access_token"]
+        headers2 = {"Authorization": f"Bearer {token2}"}
+        response = await ac.post(
+            f"/reservations/{reservation_id}/pay", headers=headers2
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_nonexistent_reservation_returns_404(
+    setup_collections: tuple[
+        AsyncIOMotorCollection, AsyncIOMotorCollection, AsyncIOMotorCollection
+    ]
+) -> None:
+    """Return 404 when cancelling a reservation that does not exist."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/auth/register", json={"username": "mark", "password": "secret"}
+        )
+        login = await ac.post(
+            "/auth/login", json={"username": "mark", "password": "secret"}
+        )
+        token = login.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        response = await ac.delete(
+            "/reservations/nonexistent-id", headers=headers
+        )
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add test for creating a reservation with a nonexistent flight returning 404
- verify paying a reservation by another user returns 404
- ensure cancelling an unknown reservation returns 404

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4089b8094832587dad2aa543552ab