### PR TITLE
Add unit tests for MongoDB repositories

### DIFF
--- a/fastapi-app/tests/test_flight_repository.py
+++ b/fastapi-app/tests/test_flight_repository.py
@@ -1,0 +1,65 @@
+"""Tests for ``FlightRepository``."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import mongomock_motor
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+# Add fastapi-app directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.repositories.flight_repository import FlightRepository  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def flight_collection() -> AsyncIOMotorCollection:
+    """Provide a mock flight collection."""
+    client = mongomock_motor.AsyncMongoMockClient()
+    collection = client["test_db"]["flights"]
+    await collection.delete_many({})
+    try:
+        yield collection
+    finally:
+        await collection.delete_many({})
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_search_and_get_by_id(flight_collection: AsyncIOMotorCollection) -> None:
+    """Ensure flights can be searched and retrieved by ID."""
+    repo = FlightRepository(flight_collection)
+    flight1 = {
+        "_id": "AB123",
+        "origin": "MEX",
+        "destination": "GDL",
+        "departure_time": datetime(2023, 1, 1, 10, 0, 0),
+        "arrival_time": datetime(2023, 1, 1, 12, 0, 0),
+        "price": 1500.0,
+        "seats": 1,
+    }
+    flight2 = {
+        "_id": "CD456",
+        "origin": "MEX",
+        "destination": "CUN",
+        "departure_time": datetime(2023, 1, 2, 10, 0, 0),
+        "arrival_time": datetime(2023, 1, 2, 12, 0, 0),
+        "price": 2000.0,
+        "seats": 2,
+    }
+    await flight_collection.insert_many([flight1, flight2])
+
+    results = await repo.search("MEX", "GDL")
+    assert len(results) == 1
+    assert results[0].id == "AB123"
+    assert results[0].price == 1500.0
+
+    fetched = await repo.get_by_id("AB123")
+    assert fetched is not None
+    assert fetched.origin == "MEX"
+
+    missing = await repo.get_by_id("ZZ999")
+    assert missing is None

--- a/fastapi-app/tests/test_reservation_repository.py
+++ b/fastapi-app/tests/test_reservation_repository.py
@@ -1,0 +1,51 @@
+"""Tests for ``ReservationRepository``."""
+
+import sys
+from pathlib import Path
+
+import mongomock_motor
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+# Add fastapi-app directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.repositories.reservation_repository import ReservationRepository  # noqa: E402
+from app.models.reservation import ReservationInDB  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def reservation_collection() -> AsyncIOMotorCollection:
+    """Provide a mock reservation collection."""
+    client = mongomock_motor.AsyncMongoMockClient()
+    collection = client["test_db"]["reservations"]
+    await collection.delete_many({})
+    try:
+        yield collection
+    finally:
+        await collection.delete_many({})
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_count_get_and_delete(reservation_collection: AsyncIOMotorCollection) -> None:
+    """Ensure reservations can be created, counted, retrieved and deleted."""
+    repo = ReservationRepository(reservation_collection)
+    res1 = ReservationInDB(id="r1", flight_id="f1", username="alice", seat_number=1, paid=False)
+    res2 = ReservationInDB(id="r2", flight_id="f1", username="bob", seat_number=2, paid=False)
+    res3 = ReservationInDB(id="r3", flight_id="f2", username="alice", seat_number=1, paid=False)
+    await repo.create(res1)
+    await repo.create(res2)
+    await repo.create(res3)
+
+    assert await reservation_collection.count_documents({}) == 3
+    assert await repo.count_by_flight("f1") == 2
+
+    fetched = await repo.get_by_id("r1")
+    assert fetched is not None
+    assert fetched.username == "alice"
+
+    await repo.delete("r1")
+    assert await repo.get_by_id("r1") is None
+    assert await repo.count_by_flight("f1") == 1

--- a/fastapi-app/tests/test_user_repository.py
+++ b/fastapi-app/tests/test_user_repository.py
@@ -1,0 +1,51 @@
+"""Tests for ``UserRepository``."""
+
+import sys
+from pathlib import Path
+
+import mongomock_motor
+import pytest
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+# Add fastapi-app directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.repositories.user_repository import UserRepository  # noqa: E402
+from app.models.user import UserInDB  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def user_collection() -> AsyncIOMotorCollection:
+    """Provide a mock user collection."""
+    client = mongomock_motor.AsyncMongoMockClient()
+    collection = client["test_db"]["users"]
+    await collection.delete_many({})
+    try:
+        yield collection
+    finally:
+        await collection.delete_many({})
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_user(user_collection: AsyncIOMotorCollection) -> None:
+    """Ensure users can be created and retrieved."""
+    repo = UserRepository(user_collection)
+    user = UserInDB(username="alice", hashed_password="secret")
+    username = await repo.create(user)
+    assert username == "alice"
+    assert await user_collection.count_documents({}) == 1
+
+    fetched = await repo.get_by_username("alice")
+    assert fetched is not None
+    assert fetched.username == "alice"
+    assert fetched.hashed_password == "secret"
+
+
+@pytest.mark.asyncio
+async def test_get_missing_user(user_collection: AsyncIOMotorCollection) -> None:
+    """Ensure ``None`` is returned when user is absent."""
+    repo = UserRepository(user_collection)
+    fetched = await repo.get_by_username("missing")
+    assert fetched is None


### PR DESCRIPTION
## Summary
- add UserRepository tests using mongomock_motor to validate create and fetch operations
- add FlightRepository tests that search by route and get flights by ID
- add ReservationRepository tests verifying create, count, retrieve and delete behaviors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a408a49a0c8325a661a79b761d703c