### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r fastapi-app/requirements.txt
+      - name: Run tests
+        run: |
+          PYTHONPATH=fastapi-app python -m pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and run tests

## Testing
- `PYTHONPATH=fastapi-app python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40dadced88325b8a73cc2a1024acd