### PR TITLE
Enforce 80% coverage in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r fastapi-app/requirements.txt
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
-          PYTHONPATH=fastapi-app python -m pytest
+          PYTHONPATH=fastapi-app python -m pytest \
+            --cov=fastapi-app \
+            --cov-report=term-missing \
+            --cov-fail-under=80

--- a/fastapi-app/requirements.txt
+++ b/fastapi-app/requirements.txt
@@ -4,6 +4,7 @@ motor
 python-jose[cryptography]
 passlib[bcrypt]
 pytest
+pytest-cov
 pytest-asyncio
 httpx
 mongomock-motor


### PR DESCRIPTION
## Summary
- add pytest-cov dependency
- ensure CI fails if coverage below 80%

## Testing
- `pip install -r fastapi-app/requirements.txt`
- `PYTHONPATH=fastapi-app python -m pytest --cov=fastapi-app --cov-report=term-missing --cov-fail-under=80`

------
https://chatgpt.com/codex/tasks/task_e_68a40f5a0ec48325813dd7c79cc0cd56