### PR TITLE
feat: add flight creation endpoint

### DIFF
--- a/casos-de-uso.md
+++ b/casos-de-uso.md
@@ -68,10 +68,10 @@ A continuación se describen los principales casos de uso del sistema, derivados
 
 **Flujo principal:**
 1. El administrador accede al módulo de gestión de vuelos.
-2. El administrador crea o edita información de un vuelo.
+2. El administrador registra un nuevo vuelo proporcionando código, origen, destino, horarios, precio y capacidad mediante el endpoint `/flights`.
 3. El sistema almacena los cambios realizados.
 
-**Postcondiciones:** El vuelo es creado o actualizado en el sistema.
+**Postcondiciones:** El vuelo queda disponible para búsquedas y reservas.
 
 ## CU7. Registro e inicio de sesión
 **Actor principal:** Usuario

--- a/fastapi-app/app/repositories/flight_repository.py
+++ b/fastapi-app/app/repositories/flight_repository.py
@@ -6,7 +6,7 @@ from ..models.flight import FlightInDB
 
 
 class FlightRepository:
-    """Repository for flight read operations."""
+    """Repository for flight operations."""
 
     def __init__(self, collection: AsyncIOMotorCollection) -> None:
         self.collection = collection
@@ -27,3 +27,10 @@ class FlightRepository:
             document["id"] = document.pop("_id")
             return FlightInDB(**document)
         return None
+
+    async def create(self, flight: FlightInDB) -> str:
+        """Insert a new flight and return its identifier."""
+        document = flight.model_dump()
+        document["_id"] = document.pop("id")
+        await self.collection.insert_one(document)
+        return flight.id

--- a/fastapi-app/app/routers/flights.py
+++ b/fastapi-app/app/routers/flights.py
@@ -6,8 +6,8 @@ from motor.motor_asyncio import AsyncIOMotorCollection
 
 from ..database import get_flight_collection
 from ..repositories.flight_repository import FlightRepository
-from ..schemas.flight import Flight
-from ..services.flight_service import get_flight, search_flights
+from ..schemas.flight import Flight, FlightCreate
+from ..services.flight_service import create_flight, get_flight, search_flights
 
 router = APIRouter(prefix="/flights", tags=["flights"])
 
@@ -34,4 +34,13 @@ async def get(flight_id: str, repo: FlightRepository = Depends(get_flight_repo))
     flight_db = await get_flight(repo, flight_id)
     if not flight_db:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Flight not found")
+    return Flight(**flight_db.model_dump())
+
+
+@router.post("", response_model=Flight, status_code=status.HTTP_201_CREATED)
+async def create(
+    data: FlightCreate, repo: FlightRepository = Depends(get_flight_repo)
+) -> Flight:
+    """Create a new flight."""
+    flight_db = await create_flight(repo, data)
     return Flight(**flight_db.model_dump())

--- a/fastapi-app/app/schemas/flight.py
+++ b/fastapi-app/app/schemas/flight.py
@@ -3,6 +3,17 @@ from datetime import datetime
 from pydantic import BaseModel
 
 
+class FlightCreate(BaseModel):
+    """Schema for creating a new flight."""
+    id: str
+    origin: str
+    destination: str
+    departure_time: datetime
+    arrival_time: datetime
+    price: float
+    seats: int
+
+
 class Flight(BaseModel):
     """Schema representing flight information."""
     id: str

--- a/fastapi-app/app/services/flight_service.py
+++ b/fastapi-app/app/services/flight_service.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from ..models.flight import FlightInDB
 from ..repositories.flight_repository import FlightRepository
+from ..schemas.flight import FlightCreate
 
 
 async def search_flights(repo: FlightRepository, origin: str, destination: str) -> List[FlightInDB]:
@@ -13,3 +14,10 @@ async def search_flights(repo: FlightRepository, origin: str, destination: str) 
 async def get_flight(repo: FlightRepository, flight_id: str) -> Optional[FlightInDB]:
     """Retrieve a flight by its identifier."""
     return await repo.get_by_id(flight_id)
+
+
+async def create_flight(repo: FlightRepository, data: FlightCreate) -> FlightInDB:
+    """Create a new flight in the repository."""
+    flight = FlightInDB(**data.model_dump())
+    await repo.create(flight)
+    return flight

--- a/fastapi-app/tests/test_flight_repository.py
+++ b/fastapi-app/tests/test_flight_repository.py
@@ -13,6 +13,7 @@ from motor.motor_asyncio import AsyncIOMotorCollection
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.repositories.flight_repository import FlightRepository  # noqa: E402
+from app.models.flight import FlightInDB  # noqa: E402
 
 
 @pytest_asyncio.fixture
@@ -63,3 +64,23 @@ async def test_search_and_get_by_id(flight_collection: AsyncIOMotorCollection) -
 
     missing = await repo.get_by_id("ZZ999")
     assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_create_inserts_flight(flight_collection: AsyncIOMotorCollection) -> None:
+    """Ensure a flight can be created."""
+    repo = FlightRepository(flight_collection)
+    flight = FlightInDB(
+        id="EF789",
+        origin="MEX",
+        destination="MTY",
+        departure_time=datetime(2023, 1, 3, 10, 0, 0),
+        arrival_time=datetime(2023, 1, 3, 12, 0, 0),
+        price=1800.0,
+        seats=3,
+    )
+    inserted_id = await repo.create(flight)
+    assert inserted_id == "EF789"
+    stored = await flight_collection.find_one({"_id": "EF789"})
+    assert stored is not None
+    assert stored["destination"] == "MTY"

--- a/fastapi-app/tests/test_flights.py
+++ b/fastapi-app/tests/test_flights.py
@@ -74,6 +74,28 @@ async def test_search_and_get_flight(flight_collection: AsyncIOMotorCollection) 
 
 
 @pytest.mark.asyncio
+async def test_create_flight(flight_collection: AsyncIOMotorCollection) -> None:
+    """Ensure a flight can be created via the API."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {
+            "id": "XY789",
+            "origin": "MEX",
+            "destination": "CUN",
+            "departure_time": datetime(2023, 2, 1, 10, 0, 0).isoformat(),
+            "arrival_time": datetime(2023, 2, 1, 12, 0, 0).isoformat(),
+            "price": 2500.0,
+            "seats": 100,
+        }
+        response = await ac.post("/flights", json=payload)
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["id"] == "XY789"
+        stored = await flight_collection.find_one({"_id": "XY789"})
+        assert stored is not None
+
+
+@pytest.mark.asyncio
 async def test_search_returns_empty_list(
     flight_collection: AsyncIOMotorCollection,
 ) -> None:

--- a/fastapi-app/tests/test_schemas.py
+++ b/fastapi-app/tests/test_schemas.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.schemas.user import UserCreate  # noqa: E402
-from app.schemas.flight import Flight  # noqa: E402
+from app.schemas.flight import Flight, FlightCreate  # noqa: E402
 from app.schemas.reservation import Reservation  # noqa: E402
 
 
@@ -53,6 +53,34 @@ def test_flight_validation_error(data: dict) -> None:
     """Invalid flight data should raise a ValidationError."""
     with pytest.raises(ValidationError):
         Flight(**data)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "id": "FL1",
+            "origin": "A",
+            "destination": "B",
+            "arrival_time": datetime.now(),
+            "price": 100.0,
+            "seats": 50,
+        },  # missing departure_time
+        {
+            "id": "FL1",
+            "origin": "A",
+            "destination": "B",
+            "departure_time": datetime.now(),
+            "arrival_time": datetime.now(),
+            "price": 100.0,
+            "seats": "many",
+        },  # invalid seats type
+    ],
+)
+def test_flight_create_validation_error(data: dict) -> None:
+    """Invalid flight creation data should raise a ValidationError."""
+    with pytest.raises(ValidationError):
+        FlightCreate(**data)
 
 
 @pytest.mark.parametrize(

--- a/requerimientos-funcionales.md
+++ b/requerimientos-funcionales.md
@@ -5,6 +5,6 @@
 3. **Reserva de asientos.** Los usuarios pueden reservar un solo asiento por vuelo y el sistema debe impedir la sobreventa.
 4. **Cancelación de reservas.** Las reservas pueden cancelarse hasta 24 horas antes de la salida y al hacerlo el asiento queda disponible nuevamente.
 5. **Proceso de pago simulado.** Al reservar se simula el pago, devolviendo un estado de aprobado o declinado.
-6. **Gestión de vuelos por administradores.** Los administradores pueden crear y editar vuelos manualmente.
+6. **Gestión de vuelos por administradores.** Los administradores pueden crear y editar vuelos manualmente mediante un endpoint dedicado.
 7. **Registro e inicio de sesión.** El registro e inicio de sesión se realiza con email y contraseña utilizando JWT.
 8. **Gestión de reservas.** Los usuarios pueden consultar las reservas asociadas a su cuenta.


### PR DESCRIPTION
## Summary
- allow creating flights via a new POST /flights endpoint
- document and test flight creation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a8a8162c83259c7bf9fa1b7b1605