### PR TITLE
Add database ER diagram and reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ Repositorio del curso Codex. Incluye documentación de análisis, diagramas de a
 - `fastapi-app/`: código de la API y pruebas automatizadas.
 - Documentos Markdown: casos de uso, requisitos, diagramas y plan de sprints.
 
+## Documentos de análisis y diagramas
+
+- [Casos de uso](casos-de-uso.md)
+- [Requerimientos funcionales](requerimientos-funcionales.md)
+- [Requerimientos no funcionales](requerimientos-no-funcionales.md)
+- [Diagramas de flujo](diagramas-flujo.md)
+- [Diagramas de secuencia](diagramas-secuencia.md)
+- [Diagrama de componentes](diagrama-componentes.md)
+- [Arquitectura monolítica](arquitectura-monolitica.md)
+- [Plan de sprints](plan-de-sprints.md)
+- [Diagrama base de datos](diagrama-base-de-datos.md)
+
 ## Requisitos
 
 Requiere Python 3.11+ y las dependencias listadas en `fastapi-app/requirements.txt`:

--- a/diagrama-base-de-datos.md
+++ b/diagrama-base-de-datos.md
@@ -1,0 +1,41 @@
+# Diagrama de Base de Datos
+
+```mermaid
+erDiagram
+    USUARIOS {
+        int id_usuario PK
+        string nombre
+        string email
+    }
+    VUELOS {
+        int id_vuelo PK
+        string numero
+        string origen
+        string destino
+        date fecha
+    }
+    RESERVAS {
+        int id_reserva PK
+        int usuario_id FK
+        int vuelo_id FK
+        date fecha_reserva
+    }
+    PAGOS {
+        int id_pago PK
+        int reserva_id FK
+        float monto
+        date fecha_pago
+    }
+
+    USUARIOS ||--o{ RESERVAS : "realiza"
+    VUELOS ||--o{ RESERVAS : "incluye"
+    RESERVAS ||--|| PAGOS : "se liquida"
+```
+
+## Descripción de entidades
+
+- **usuarios**: almacena la información de los clientes registrados.
+- **vuelos**: contiene los detalles de los vuelos disponibles.
+- **reservas**: vincula usuarios con vuelos y registra la fecha de reserva.
+- **pagos**: guarda los registros de pago para cada reserva.
+


### PR DESCRIPTION
## Summary
- document database structure with Mermaid ER diagram and entity descriptions
- list analysis and diagram documents in README with link to database diagram

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5f4d00abc83258df364a8370c966f